### PR TITLE
Parse escaped backslashes correctly

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -89,7 +89,7 @@ CSSOM.parse = function parse(token) {
 				if (!index) {
 					parseError('Unmatched "');
 				}
-			} while (token[index - 2] === '\\');
+			} while (token[index - 2] === '\\' && token[index - 3] !== '\\');
 			buffer += token.slice(i, index);
 			i = index - 1;
 			switch (state) {
@@ -109,7 +109,7 @@ CSSOM.parse = function parse(token) {
 				if (!index) {
 					parseError("Unmatched '");
 				}
-			} while (token[index - 2] === '\\');
+			} while (token[index - 2] === '\\' && token[index - 3] !== '\\');
 			buffer += token.slice(i, index);
 			i = index - 1;
 			switch (state) {

--- a/spec/parse.spec.js
+++ b/spec/parse.spec.js
@@ -1291,6 +1291,11 @@ describe('parse', function() {
 		expect(parsed.cssRules[0].style.content).toBe('"\\""');
 	});
 
+	given('a{content:"\\""}', function(input) {
+		var parsed = CSSOM.parse(input);
+		expect(parsed.cssRules[0].style.content).toBe('"\\""');
+	});
+
 	given("a{content:'\\''}", function(input) {
 		var parsed = CSSOM.parse(input);
 		expect(parsed.cssRules[0].style.content).toBe("'\\''");
@@ -1306,6 +1311,15 @@ describe('parse', function() {
 		expect(parsed.cssRules[0].style.content).toBe("'abc\\'\\'d\\'ef'");
 	});
 
+	given('a{content:"\\\\"}', function(input) {
+		var parsed = CSSOM.parse(input);
+		expect(parsed.cssRules[0].style.content).toBe('"\\\\"');
+	});
+
+	given("a{content:'\\\\'}", function(input) {
+		var parsed = CSSOM.parse(input);
+		expect(parsed.cssRules[0].style.content).toBe("'\\\\'");
+	});
 });
 });
 


### PR DESCRIPTION
Currently CSS rules containing escaped backslashes inside a string will fail
to be parsed correctly.  A minimal example of a failing CSS rule one which prepends
a backslash to an element using the '::before' pseudo-element:

```
a::before {
    content: "\\"
}
```

This will currently fail with the following message:

```
Error: Unmatched " (line x, char y) (line x)
```

The fix is to check for this condition in the do-while loops that are part of
the string parsing logic.